### PR TITLE
userChangeModalの側のみ実装

### DIFF
--- a/src/component/changeTL.tsx
+++ b/src/component/changeTL.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { useSetRecoilState } from 'recoil'
+import { StyleSheet, View, Text, SafeAreaView } from 'react-native'
+import UserChange from './userChangeModal'
+import { userChangeFlgState } from '../state/atoms/userChangeAtom'
+
+/** 対象ユーザのprof/TLを切り替えるコンポーネント */
+export default function TlButton() {
+  const setUserChangeFlg = useSetRecoilState(userChangeFlgState)
+  return (
+    <SafeAreaView>
+      <View style={styles.buttonStyle}>
+        <Text onPress={() => setUserChangeFlg(true)}>changeTL</Text>
+      </View>
+      <UserChange />
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  buttonStyle: {
+    alignSelf: 'center',
+    borderBottomColor: 'black',
+    borderBottomWidth: 1,
+    borderTopColor: 'black',
+    borderTopWidth: 1,
+    paddingHorizontal: 20,
+    paddingVertical: 8,
+  },
+})

--- a/src/component/userChangeModal.tsx
+++ b/src/component/userChangeModal.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import { useRecoilState } from 'recoil'
+import { userChangeFlgState } from '../state/atoms/userChangeAtom'
+import { Modal, Text, Pressable, View } from 'react-native'
+import StyleSheet from 'react-native-media-query'
+
+export default function UserChange() {
+  const [userChangeFlg, setUserChangeFlg] = useRecoilState(userChangeFlgState)
+  return (
+    <View style={styles.centeredView}>
+      <Modal animationType="slide" transparent={true} visible={userChangeFlg}>
+        <View style={styles.centeredView}>
+          <View style={styles.modalView} dataSet={{ media: ids.modalView }}>
+            <Text style={styles.modalText}>
+              ここに表示したいUserの名前を一覧表示する。
+            </Text>
+            <Pressable
+              style={[styles.button, styles.buttonClose]}
+              onPress={() => {
+                setUserChangeFlg(false)
+              }}
+            >
+              <Text style={styles.textStyle}>Hide Modal</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  )
+}
+
+const { ids, styles } = StyleSheet.create({
+  centeredView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 22,
+  },
+  modalView: {
+    backgroundColor: 'white',
+    borderWidth: 2,
+    borderRadius: 20,
+    paddingVertical: 100,
+    paddingHorizontal: 100,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+    '@media (min-width: 428px)': {
+      backgroundColor: 'red',
+    },
+  },
+  button: {
+    borderRadius: 20,
+    padding: 10,
+    elevation: 2,
+  },
+  buttonOpen: {
+    backgroundColor: '#F194FF',
+  },
+  buttonClose: {
+    backgroundColor: '#2196F3',
+  },
+  textStyle: {
+    color: 'white',
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  modalText: {
+    marginBottom: 15,
+    textAlign: 'center',
+  },
+})

--- a/src/page/home.tsx
+++ b/src/page/home.tsx
@@ -1,15 +1,21 @@
 import { SafeAreaView, StyleSheet, View, Text, ScrollView } from 'react-native'
+import { useRecoilValue } from 'recoil'
+import TlButton from '../component/changeTL'
+import { userChangeFlgState } from '../state/atoms/userChangeAtom'
 
 /** homeコンポーネント */
 export default function Home() {
+  const userChangeFlg = useRecoilValue(userChangeFlgState)
+
   return (
     <SafeAreaView>
-      <View style={styles.container}>
+      <View style={[!userChangeFlg ? styles.container : styles.afterContainer]}>
         <View style={styles.profArea}>
           <Text>プロフィール表示エリア</Text>
         </View>
         <View style={styles.modalArea}>
-          <Text>Modalボタン表示エリア</Text>
+          <TlButton />
+          <Text>ツイートModal表示エリア</Text>
         </View>
         <ScrollView style={styles.scrollView}>
           <Text style={styles.text}>
@@ -35,6 +41,9 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#fff',
   },
+  afterContainer: {
+    opacity: 0.3,
+  },
   profArea: {
     borderWidth: 2,
     alignItems: 'center',
@@ -45,6 +54,8 @@ const styles = StyleSheet.create({
     marginVertical: 20,
     paddingTop: 20,
     borderWidth: 2,
+    flexDirection: 'row',
+    paddingHorizontal: 20,
   },
   tlArea: {
     marginHorizontal: 20,

--- a/src/state/atoms/userChangeAtom.ts
+++ b/src/state/atoms/userChangeAtom.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil'
+
+/** UserChangeModal表示制御Atom */
+export const userChangeFlgState = atom<boolean>({
+  key: 'CHANGE_USER_FLG',
+  default: false,
+})


### PR DESCRIPTION
# userChangeModalの側のみ実装
「changeTL」ボタン押下後に表示する`userChangeModal`の側だけ実装
機能側についてはTwitterのDevアカウント申請後に実装予定

## 変更点

- src/component/changeTL.tsx
  - 「changeTL」ボタン押下後に`userChangeModal`を表示するよう実装致しました。
- src/component/userChangeModal.tsx
  - TLを表示するUserを切り替えるModalを実装致しました。
- src/page/home.tsx
  - `userChangeModal`表示中に背景を透過するように実装致しました。
  - Modal表示箇所にツイートボタンのダミーを設置致しました。
- src/state/atoms/userChangeAtom.ts
  - TL切り替え用のAtomを追加致しました。

## その他
実際の機能については実装しておりません。
globalStateの取り扱いについては検討中のため、今後大きく変更する可能性あり。
